### PR TITLE
This change is recommended to help jorgan-fluidsynth build on macs

### DIFF
--- a/jorgan-fluidsynth/build.xml
+++ b/jorgan-fluidsynth/build.xml
@@ -141,6 +141,7 @@
       <arg value="-dynamiclib" />
       <arg value="-std=c99" />
       <arg value="-I${mac.include}" />
+      <arg value="-I${mac.include}/darwin" />	    
       <arg value="-I../jorgan-jni/src/main/native" />
       <arg value="-I./lib/include" />
       <arg value="-I./target/native" />


### PR DESCRIPTION
This is to allow java's jni.h to include darwin/jni_md.h on macs.