### PR TITLE
Build with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build CI/CD
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Install packages
+      run: sudo apt install -y libasound2-dev libfluidsynth-dev
+    - name: Build with Ant
+      run: ant -noinput -Dunix.include=$JAVA_HOME/include -buildfile build.xml
+    - name: Build ZIP with Ant
+      run: ant -noinput -Dunix.include=$JAVA_HOME/include -buildfile jorgan/build.xml
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        path: jorgan/target/*.zip
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: jorgan/target/*.zip


### PR DESCRIPTION
This creates a GitHub Actions workflow to automatically build jOrgan, which will build when any push or pull request is created, and output an artifact like [this](https://github.com/svenmeier/jorgan/files/12841244/artifact.zip). If it is triggered by the creation of a tag it will automatically create a GitHub release, which will contain the ZIP file of the build.